### PR TITLE
Dynamically allow tenancies access to Machines, Volumes, Kubernetes and Kubernetes Apps based on discovery of the portal-internal network 

### DIFF
--- a/api/azimuth/provider/dto.py
+++ b/api/azimuth/provider/dto.py
@@ -17,6 +17,9 @@ class Capabilities:
     #: Indicates if the cloud supports volumes
     supports_volumes: bool = False
 
+    #: Indicates if machines are enabled for the cloud
+    supports_machines: bool = True
+
 
 @dataclass(frozen=True)
 class Tenancy:

--- a/api/azimuth/provider/dto.py
+++ b/api/azimuth/provider/dto.py
@@ -20,6 +20,12 @@ class Capabilities:
     #: Indicates if machines are enabled for the cloud
     supports_machines: bool = True
 
+    #: Indicates if kubernetes is enabled for the cloud
+    supports_kubernetes: bool = True
+
+    #: Indicates if kubernetes apps are enabled for the cloud
+    supports_apps: bool = True
+
 
 @dataclass(frozen=True)
 class Tenancy:

--- a/api/azimuth/provider/null.py
+++ b/api/azimuth/provider/null.py
@@ -35,4 +35,7 @@ class ScopedSession(base.ScopedSession):
     provider_name = "null"
 
     def capabilities(self):
-        return dto.Capabilities(supports_volumes=False)
+        return dto.Capabilities(
+            supports_volumes=False,
+            supports_machines=False,
+        )

--- a/chart/files/api/settings/04-cloud-provider.yaml
+++ b/chart/files/api/settings/04-cloud-provider.yaml
@@ -18,6 +18,7 @@ AZIMUTH:
       {{- with .Values.provider.openstack.internalNetDNSNameservers }}
       INTERNAL_NET_DNS_NAMESERVERS: {{ toYaml . | nindent 8 }}
       {{- end }}
+      SUPPORTS_MACHINES: {{ .Values.provider.openstack.supportsMachines }}
     {{- else if (eq .Values.provider.type "null")}}
     FACTORY: azimuth.provider.null.Provider
     PARAMS: {}

--- a/chart/files/api/settings/04-cloud-provider.yaml
+++ b/chart/files/api/settings/04-cloud-provider.yaml
@@ -10,6 +10,7 @@ AZIMUTH:
       EXTERNAL_NET_TEMPLATE: {{ . | quote }}
       {{- end }}
       CREATE_INTERNAL_NET: {{ .Values.provider.openstack.createInternalNet }}
+      ALLOW_SHARED_INTERNAL_NET: {{ .Values.provider.openstack.allowSharedInternalNet }}
       MANILA_PROJECT_SHARE_GB: {{ .Values.provider.openstack.manilaProjectShareGB }}
       {{- with .Values.provider.openstack.internalNetCidr }}
       INTERNAL_NET_CIDR: {{ . | quote }}

--- a/chart/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/chart/tests/__snapshot__/snapshot_test.yaml.snap
@@ -158,7 +158,7 @@ templated manifests should match snapshot:
       template:
         metadata:
           annotations:
-            azimuth.stackhpc.com/settings-checksum: bc5895d098cbdf0ac8bdeb4bb6aa789ae8f37366cbd33a7d56979e08e7680f6c
+            azimuth.stackhpc.com/settings-checksum: 4456f249ad2b10af8275e59c37bb0435e01dcc236bdb926b6ebc3c19ba8eeea6
             azimuth.stackhpc.com/theme-checksum: ec0f36322392deee39d80b7f77ecd634df60358857af9dc208077860c4e174ab
             kubectl.kubernetes.io/default-container: api
           labels:
@@ -256,7 +256,7 @@ templated manifests should match snapshot:
       03-authentication.yaml: |
         IyBOZXctc3R5bGUgYXV0aGVudGljYXRpb24gY29uZmlndXJhdGlvbgojIEF1dGhlbnRpY2F0aW9uIGlzIGRlZmluZWQgYnkgY2xvdWQgdHlwZSBhbmQgcmV1c2VkIGJ5IGNvbXBvbmVudHMgYXMgbmVlZGVkCkFaSU1VVEhfQVVUSDoKICBBVVRIX1RZUEU6IG9wZW5zdGFjawogIE9QRU5TVEFDSzoKICAgIEFVVEhfVVJMOiAiaHR0cHM6Ly9leGFtcGxlLmNvbSIKICAgIElOVEVSRkFDRTogInB1YmxpYyIKICAgIFZFUklGWV9TU0w6IHRydWUKICAgIEFQUENSRURfSElEREVOOiB0cnVlCiAgICBQQVNTV09SRF9FTkFCTEVEOiB0cnVlCiAgICBQQVNTV09SRF9ET01BSU5TOgogICAgICAtIG5hbWU6ICJkZWZhdWx0IgogICAgICAgIGxhYmVsOiAiVXNlcm5hbWUgKyBQYXNzd29yZCIK
       04-cloud-provider.yaml: |
-        QVpJTVVUSDoKICBQUk9WSURFUjoKICAgIEZBQ1RPUlk6IGF6aW11dGgucHJvdmlkZXIub3BlbnN0YWNrLlByb3ZpZGVyCiAgICBQQVJBTVM6CiAgICAgIENSRUFURV9JTlRFUk5BTF9ORVQ6IHRydWUKICAgICAgTUFOSUxBX1BST0pFQ1RfU0hBUkVfR0I6IDAK
+        QVpJTVVUSDoKICBQUk9WSURFUjoKICAgIEZBQ1RPUlk6IGF6aW11dGgucHJvdmlkZXIub3BlbnN0YWNrLlByb3ZpZGVyCiAgICBQQVJBTVM6CiAgICAgIENSRUFURV9JTlRFUk5BTF9ORVQ6IHRydWUKICAgICAgQUxMT1dfU0hBUkVEX0lOVEVSTkFMX05FVDogZmFsc2UKICAgICAgTUFOSUxBX1BST0pFQ1RfU0hBUkVfR0I6IDAKICAgICAgU1VQUE9SVFNfTUFDSElORVM6IHRydWUK
       05-apps.yaml: |
         Cg==
       06-ssh-key-store.yaml: |

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -269,6 +269,8 @@ provider:
     externalNetTemplate:
     # Indicates whether tenant internal networks should be auto-created if not present
     createInternalNet: true
+    # Indicates whether networks shared into the project may be considered for internal network
+    allowSharedInternalNet: false
     # If larger than zero, project specific manila share should be auto-created
     manilaProjectShareGB: 0
     # The CIDR to use for auto-created tenant internal networks

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -279,6 +279,8 @@ provider:
     # The nameservers to use for auto-created tenant internal networks
     # Defaults to an empty list if not given.
     internalNetDNSNameservers:
+    # Indicates whether support for operations on OpenStack machines is enabled
+    supportsMachines: true
 
 # Settings for apps
 apps:

--- a/ui/src/components/pages/tenancy/index.js
+++ b/ui/src/components/pages/tenancy/index.js
@@ -91,9 +91,13 @@ const TenancyNav = ({
     const [userExpanded, setUserExpanded] = useState(false);
     const toggleUserExpanded = () => setUserExpanded(expanded => !expanded);
     const selectedResourceIsAdvanced = ['machines', 'volumes'].includes(selectedResource);
+    
     // If the cloud doesn't support platforms, always show the advanced resources
-    // If the user is on an advanced tab, show the items even if they are not expanded
-    const showAdvanced = (userExpanded || !supportsPlatforms || selectedResourceIsAdvanced);
+    // If the cloud doesn't support machines or volumes, don't show the advanced tab
+    const showAdvanced = (capabilities.supports_machines && capabilities.supports_volumes) || !supportsPlatforms
+    // If the cloud doesn't support platforms, always show the advanced resources
+    // If the user is on an advanced tab, expand the items even if they are not expanded
+    const expandAdvanced = (userExpanded || !supportsPlatforms || selectedResourceIsAdvanced);
 
     return (
         <div className={`sidebar${sidebarExpanded ? " expanded" : ""}`}>
@@ -151,13 +155,13 @@ const TenancyNav = ({
                         </Nav.Link>
                     </Nav.Item>
                 )}
-                {supportsPlatforms && (
+                {showAdvanced && (
                     <Nav.Item as="li">
                         <Nav.Link
                             title="Advanced"
                             onClick={toggleUserExpanded}
                             disabled={selectedResourceIsAdvanced}
-                            className={`nav-toggle toggle-${showAdvanced ? "show" : "hide"}`}
+                            className={`nav-toggle toggle-${expandAdvanced ? "show" : "hide"}`}
                         >
                             <FontAwesomeIcon
                                 icon={faTools}
@@ -167,7 +171,7 @@ const TenancyNav = ({
                         </Nav.Link>
                     </Nav.Item>
                 )}
-                {showAdvanced && (
+                {expandAdvanced && (
                     <>
                         <Nav.Item as="li" className={supportsPlatforms ? "nav-item-nested" : undefined}>
                             <LinkContainer to={`/tenancies/${currentTenancy.id}/machines`}>

--- a/ui/src/redux/tenancies/capabilities.js
+++ b/ui/src/redux/tenancies/capabilities.js
@@ -31,6 +31,7 @@ const initialState = {
 
     // Defaults for the actual data
     supports_volumes: false,
+    supports_machines: false,
     supports_clusters: false,
     supports_kubernetes: false,
     supports_apps: false,


### PR DESCRIPTION
### Internal network is a shared network
Add a new config option to the openstack provider - `internalNetIsShared` - which allows a network shared into a project to be used as the portal-internal network.

If `internalNetIsShared` is True, shared networks that are available to the project and have the `portal-internal` tag are preferentially chosen as the portal-internal network over those that are owned by the project.

There are no changes to the default behaviour, and projects that do not have access to a **shared** network with the `portal-internal` tag will use an existing network owned by the project if it is available, or a new network will be created if `createInternalNet` is True (the default).

### Internal network doesn't exist
If the internal network can not be detected and `createInternalNet` is False, the capabilites returned for a scoped session are updated to disable machines, volumes, Kubernetes and Kubernetes apps  API endpoints, because creating resources of these types relies on the internal network being determined. The UI reacts to the disabling of these endpoints by removing the relevant items from the sidebar (Advanced>Machines, Volumes) or from the platforms catalogue (Kubernetes and Kubernetes apps).

### Machines functionality disabled
The "machines" functionality may be disabled for the OpenStack provider by setting `supportsMachines` to False (default is True). This will disable operations on machines and volumes across all projects, and will cause the "advanced" menu element to be removed from the UI.

### Dynamic project capabilities vs configured capabilities
Configuration options remain for enabling and disabling CaaS, Kubernetes and Kubernetes apps, alongside a new configuration option for Machines. If a capability is disabled in config, it will not be enabled dynamically on a per-tenant basis. If a capability is enabled in config, it may be disabled on a per-tenant basis if the prerequisites for the capability are not present (for example, the internal network was not able to be determined for a project, so machines, volumes, Kubernetes and Kubernetes Apps are dynamically disabled even though they are enabled in configuration).