### PR TITLE
Change [volume] catalog_type default to block-storage

### DIFF
--- a/api/azimuth/provider/openstack/api/block_store.py
+++ b/api/azimuth/provider/openstack/api/block_store.py
@@ -49,7 +49,7 @@ class BlockStoreService(Service):
     """
 
     name = "block_store"
-    catalog_type = "volumev3"
+    catalog_type = "block-storage"
     path_prefix = "/v3/{project_id}"
 
     limits = Endpoint(Limits)


### PR DESCRIPTION
There are movements to standardise on this new name [1]. Tempest testing does not work out-the-box without this change, as they moved to ``block-storage`` already [2].

Also replace references to cinder via catalog_info to just selecting the interface instead. This makes the configuration more consistent across all services.

1. https://lists.openstack.org/archives/list/openstack-discuss@lists.openstack.org/thread/QQ7L44VE4MOWOQVOFCZQPTIVI35A6SCK/
2. https://github.com/openstack/tempest/commit/1a744c8042d3c5c5ad153ef1e645975428ba0dfe