### PR TITLE
block_store service renamed to block_storage

### DIFF
--- a/api/azimuth/provider/openstack/api/block_store.py
+++ b/api/azimuth/provider/openstack/api/block_store.py
@@ -48,7 +48,7 @@ class BlockStoreService(Service):
     OpenStack service class for the block store service.
     """
 
-    name = "block_store"
+    name = "block_storage"
     catalog_type = "volumev3"
     path_prefix = "/v3/{project_id}"
 


### PR DESCRIPTION
The block_store service object has been renamed to block_storage to align the API with the official service types.