### PR TITLE
Allow line wrapping in details table.

### DIFF
--- a/ui/assets/tweaks.css
+++ b/ui/assets/tweaks.css
@@ -259,7 +259,6 @@
 }
 .details-table > :not(caption) > * > * {
     padding: 0.5rem 1rem;
-    white-space: nowrap;
     vertical-align: middle;
 }
 .details-table > * > * > *:first-child {


### PR DESCRIPTION
Not allowing line wrapping causes an overflow when template names are very long.
I can see no reason to disallow wrapping, since the box just grows taller if it holds more content.