### PR TITLE
feat: Add ui & api for exposing controlplane cert expiry

### DIFF
--- a/.stestr.conf
+++ b/.stestr.conf
@@ -1,3 +1,3 @@
 [DEFAULT]
 test_path=./api/tests
-top_dir=./
+top_dir=./api

--- a/api/azimuth/cluster_api/base.py
+++ b/api/azimuth/cluster_api/base.py
@@ -282,6 +282,21 @@ class Session:
             cluster_status.get("kubernetesVersion"),
             cluster_state,
             cluster_status.get("controlPlanePhase", "Unknown"),
+            (
+                dateutil.parser.parse(
+                    cluster_status["controlPlaneCertificateExpiryDate"]
+                )
+                if cluster_status.get("controlPlaneCertificateExpiryDate")
+                else None
+            ),
+            cluster_status.get("controlPlaneCertificateRotationDays"),
+            (
+                dateutil.parser.parse(
+                    cluster_status["controlPlaneCertificateRotationDate"]
+                )
+                if cluster_status.get("controlPlaneCertificateRotationDate")
+                else None
+            ),
             [
                 dto.Node(
                     name,

--- a/api/azimuth/cluster_api/dto.py
+++ b/api/azimuth/cluster_api/dto.py
@@ -142,6 +142,12 @@ class Cluster:
     status: str | None
     #: The status of the control plane
     control_plane_status: str | None
+    #: The earliest known kube-api server certificate expiry date
+    control_plane_certificate_expiry_date: datetime.datetime | None
+    #: The number of days before expiry when automatic certificate rotation starts
+    control_plane_certificate_rotation_days: int | None
+    #: The expected start date for automatic control plane certificate rotation
+    control_plane_certificate_rotation_date: datetime.datetime | None
     #: The nodes in the cluster
     nodes: list[Node]
     #: The addons for the cluster

--- a/api/tests/test_cluster_api.py
+++ b/api/tests/test_cluster_api.py
@@ -1,0 +1,87 @@
+import datetime
+import json
+import types
+import unittest
+
+# Load the DTO definitions before the base module to match the application import order.
+import azimuth.cluster_api.dto as capi_dto
+from azimuth.cluster_api import base
+
+
+class AttrDict(dict):
+    __getattr__ = dict.__getitem__
+
+
+class ClusterApiTest(unittest.TestCase):
+    def test_cluster_certificate_status_is_exposed(self):
+        spec = {
+            "templateName": "kubernetes-v1.34",
+            "controlPlaneMachineSize": "medium",
+            "nodeGroups": [],
+            "autohealing": True,
+            "addons": {},
+        }
+        cluster = AttrDict(
+            metadata=AttrDict(
+                name="test-cluster",
+                creationTimestamp="2026-07-31T12:00:00Z",
+                annotations={
+                    "azimuth.stackhpc.com/last-handled-configuration": json.dumps(
+                        {"spec": spec}
+                    )
+                },
+            ),
+            spec=spec,
+            status={
+                "phase": "Ready",
+                "controlPlanePhase": "Ready",
+                "controlPlaneCertificateExpiryDate": "2027-07-31T12:00:00Z",
+                "controlPlaneCertificateRotationDays": 21,
+                "controlPlaneCertificateRotationDate": "2027-07-10T12:00:00Z",
+            },
+        )
+        sizes = [types.SimpleNamespace(id="medium-id", name="medium")]
+
+        client = types.SimpleNamespace(close=lambda: None)
+        result = base.Session(client, None)._from_api_cluster(cluster, sizes)
+
+        self.assertIsInstance(result, capi_dto.Cluster)
+        self.assertEqual(
+            result.control_plane_certificate_expiry_date,
+            datetime.datetime(2027, 7, 31, 12, tzinfo=datetime.timezone.utc),
+        )
+        self.assertEqual(result.control_plane_certificate_rotation_days, 21)
+        self.assertEqual(
+            result.control_plane_certificate_rotation_date,
+            datetime.datetime(2027, 7, 10, 12, tzinfo=datetime.timezone.utc),
+        )
+
+    def test_missing_cluster_certificate_status_is_supported(self):
+        spec = {
+            "templateName": "kubernetes-v1.34",
+            "controlPlaneMachineSize": "medium",
+            "nodeGroups": [],
+            "autohealing": True,
+            "addons": {},
+        }
+        cluster = AttrDict(
+            metadata=AttrDict(
+                name="test-cluster",
+                creationTimestamp="2026-07-31T12:00:00Z",
+                annotations={
+                    "azimuth.stackhpc.com/last-handled-configuration": json.dumps(
+                        {"spec": spec}
+                    )
+                },
+            ),
+            spec=spec,
+            status={"phase": "Ready", "controlPlanePhase": "Ready"},
+        )
+        sizes = [types.SimpleNamespace(id="medium-id", name="medium")]
+
+        client = types.SimpleNamespace(close=lambda: None)
+        result = base.Session(client, None)._from_api_cluster(cluster, sizes)
+
+        self.assertIsNone(result.control_plane_certificate_expiry_date)
+        self.assertIsNone(result.control_plane_certificate_rotation_days)
+        self.assertIsNone(result.control_plane_certificate_rotation_date)

--- a/ui/assets/tweaks.css
+++ b/ui/assets/tweaks.css
@@ -30,6 +30,12 @@
 .btn-link { padding: 0 !important; }
 .btn-link:focus { box-shadow: none !important; }
 
+/* Keep keyboard focus visible on the certificate renewal popover trigger */
+.certificate-renewal-trigger:focus-visible {
+    outline: 0.25rem solid rgba(var(--bs-primary-rgb), 0.25);
+    outline-offset: 0.125rem;
+}
+
 
 /**
  * Styles for rendering pre elements in a modal.

--- a/ui/src/components/pages/tenancy/platforms/kubernetes/card.js
+++ b/ui/src/components/pages/tenancy/platforms/kubernetes/card.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useId, useState } from 'react';
 
 import Badge from 'react-bootstrap/Badge';
 import Button from 'react-bootstrap/Button';
@@ -6,11 +6,14 @@ import Card from 'react-bootstrap/Card';
 import Col from 'react-bootstrap/Col';
 import Modal from 'react-bootstrap/Modal';
 import Nav from 'react-bootstrap/Nav';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Popover from 'react-bootstrap/Popover';
 import Row from 'react-bootstrap/Row';
 import Table from 'react-bootstrap/Table';
 import Tab from 'react-bootstrap/Tab';
 
 import get from 'lodash/get';
+import { DateTime } from 'luxon';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
@@ -247,6 +250,78 @@ const WorkersStatus = ({ kubernetesCluster }) => {
 };
 
 
+const CertificateExpiry = ({ expiryDate }) => {
+    const expired = expiryDate <= DateTime.now();
+    const expiresSoon = expiryDate <= DateTime.now().plus({ days: 30 });
+
+    if( expired ) {
+        return (
+            <strong className="text-danger">
+                <FontAwesomeIcon icon={faTimesCircle} className="me-2" />
+                Expired on {expiryDate.toFormat('d LLLL yyyy')}
+            </strong>
+        );
+    }
+    else if( expiresSoon ) {
+        return (
+            <strong className="text-warning">
+                <FontAwesomeIcon icon={faExclamationTriangle} className="me-2" />
+                Expires {expiryDate.toFormat('d LLLL yyyy')}
+            </strong>
+        );
+    }
+    else {
+        return <>Expires {expiryDate.toFormat('d LLLL yyyy')}</>;
+    }
+};
+
+
+const CertificateRenewal = ({ renewalDate }) => {
+    const popoverId = useId();
+    return (
+        <>
+            <OverlayTrigger
+                placement="top"
+                overlay={(
+                    <Popover id={popoverId}>
+                        <Popover.Header>
+                            <FontAwesomeIcon
+                                icon={faExclamationTriangle}
+                                className="text-warning me-2"
+                            />
+                            Automatic certificate renewal
+                        </Popover.Header>
+                        <Popover.Body>
+                            Azimuth renews Kubernetes API server certificates by replacing
+                            the affected control plane nodes. During renewal, the control
+                            plane may temporarily operate with reduced redundancy. Renewal
+                            starts automatically before the certificates expire to prevent
+                            loss of access to the Kubernetes API.
+                        </Popover.Body>
+                    </Popover>
+                )}
+                trigger="click"
+                rootClose
+            >
+                <Button
+                    type="button"
+                    variant="link"
+                    className={
+                        "certificate-renewal-trigger small text-muted text-start " +
+                        "text-decoration-underline p-0 align-baseline"
+                    }
+                >
+                Will renew automatically on
+                </Button>
+            </OverlayTrigger>
+            <span className="d-block small text-muted text-nowrap">
+                {renewalDate.toFormat('d LLLL yyyy')}
+            </span>
+        </>
+    );
+};
+
+
 const ClusterOverviewCard = ({ kubernetesCluster, kubernetesClusterTemplates }) => (
     <Card className="mb-3">
         <Card.Header className="text-center">Cluster details</Card.Header>
@@ -349,6 +424,34 @@ const ControlPlaneCard = ({ kubernetesCluster, sizes }) => (
                     <th>Node Count</th>
                     <td>{kubernetesCluster.nodes.filter(n => n.role === "control-plane").length}</td>
                 </tr>
+                {(kubernetesCluster.control_plane_certificate_expiry_date ||
+                    kubernetesCluster.control_plane_certificate_rotation_date) && (
+                    <tr>
+                        <th className="align-top">Kubernetes API Certificate</th>
+                        <td>
+                            {kubernetesCluster.control_plane_certificate_expiry_date && (
+                                <CertificateExpiry
+                                    expiryDate={
+                                        kubernetesCluster
+                                            .control_plane_certificate_expiry_date
+                                    }
+                                />
+                            )}
+                            {kubernetesCluster.control_plane_certificate_rotation_date && (
+                                <>
+                                    {kubernetesCluster
+                                        .control_plane_certificate_expiry_date && <br />}
+                                    <CertificateRenewal
+                                        renewalDate={
+                                            kubernetesCluster
+                                                .control_plane_certificate_rotation_date
+                                        }
+                                    />
+                                </>
+                            )}
+                        </td>
+                    </tr>
+                )}
             </tbody>
         </Table>
     </Card>

--- a/ui/src/redux/tenancies/kubernetes-clusters.js
+++ b/ui/src/redux/tenancies/kubernetes-clusters.js
@@ -37,6 +37,16 @@ const {
         ),
         created_at: DateTime.fromISO(cluster.created_at),
         updated_at: !!cluster.updated_at ? DateTime.fromISO(cluster.updated_at) : undefined,
+        control_plane_certificate_expiry_date: (
+            !!cluster.control_plane_certificate_expiry_date ?
+                DateTime.fromISO(cluster.control_plane_certificate_expiry_date) :
+                undefined
+        ),
+        control_plane_certificate_rotation_date: (
+            !!cluster.control_plane_certificate_rotation_date ?
+                DateTime.fromISO(cluster.control_plane_certificate_rotation_date) :
+                undefined
+        ),
         schedule: !!cluster.schedule ? transformSchedule(cluster.schedule) : null
     })
 });


### PR DESCRIPTION
## Quick Summary

add Exposing controlplane's certificate expiry information on Azimuth UI & API
The Azimuth API now reads the certificate status published by azimuth-capi-operator, and the UI displays:
- the earliest known controlplane certificate expiry date
- `control_plane_certificate_expiry_date`: expected date of machine's cert expiration
- `control_plane_certificate_rotation_days`: number of spec.rollout.before.certificatesExpiryDays on KCP
- `control_plane_certificate_rotation_date`: calculated auto replacement date with `control_plane_certificate_expiry_date` and `control_plane_certificate_rotation_days`

the fields would be hidden when certificate information is unavailable, and this is `visibility-only` implementation for exposing the information only. no manual renewal action button is included.

## Testing
- added API conversion tests for present and missing certificate status
- testing api & ui on ha management cluster of leafcloud

## AS-IS vs TO-BE
### AS-IS (current)
<img width="561" height="207" alt="image" src="https://github.com/user-attachments/assets/e9f4dccc-df48-4d50-8bd8-930558020aad" />


### TO-BE
(if `KCP.spec.rollout.before.certificatesExpiryDays` is set)
- expose **certificate expiry day**, **expected auto replacement day**, and **auto-replacement notification message** below
<img width="1124" height="584" alt="image" src="https://github.com/user-attachments/assets/cdce778f-addd-4388-8dde-384dce2302d2" />

