### PR TITLE
fixed tilt config working directory

### DIFF
--- a/tilt-component.yaml
+++ b/tilt-component.yaml
@@ -32,19 +32,10 @@ port_forwards:
 
 local_resources:
   azimuth-ui-install:
-    cmd:
-      - yarn
-      - --cwd
-      - ./ui
-      - install
-      - --frozen-lockfile
+    cmd: "cd ./ui && yarn install --frozen-lockfile"
   azimuth-ui:
     resource_deps:
       - azimuth-ui-install
-    serve_cmd:
-      - yarn
-      - --cwd
-      - ./ui
-      - serve
+    serve_cmd: "cd ./ui && yarn serve"
     links:
       - http://localhost:3000


### PR DESCRIPTION
previous setup threw yarn version related errors as the --cwd flag only changes the working directory after yarn initializes, meaning that it does not use the version of yarn specified in the package.json file inside azimuth/ui.